### PR TITLE
Add glama.json for MCP server registry

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "gauravverma"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `glama.json` configuration file for registering the SuprSend CLI as an MCP server on [Glama](https://glama.ai)

## Test plan
- [ ] Verify `glama.json` is valid against the schema at `https://glama.ai/mcp/schemas/server.json`