### PR TITLE
ci(npm): use Node 24 + setup-node@v6 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write # Required to create releases and upload artifacts
-  id-token: write # Required for OIDC authentication to AWS
+  id-token: write # Required for OIDC: AWS (cosign signing) + npm (trusted publishing)
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,13 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 20's bundled npm (10.x) doesn't support OIDC trusted-publishing
+      # token exchange — it signs the provenance attestation but still tries
+      # to publish with the setup-node placeholder _authToken, resulting in
+      # 404 from the registry. npm 11.5+ performs the exchange automatically.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         run: scripts/publish-npm.sh "${GITHUB_REF_NAME#v}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,18 +80,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Node 24 + setup-node@v6 is what npm documents for trusted publishing.
+      # Older combos (Node 20 + setup-node@v4 ship npm 10.x) sign the provenance
+      # but don't perform the OIDC token exchange, so publishes 404 against the
+      # setup-node placeholder _authToken. See
+      # https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      # Node 20's bundled npm (10.x) doesn't support OIDC trusted-publishing
-      # token exchange — it signs the provenance attestation but still tries
-      # to publish with the setup-node placeholder _authToken, resulting in
-      # 404 from the registry. npm 11.5+ performs the exchange automatically.
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: scripts/publish-npm.sh "${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Problem

The first 0.2.22 release ([run 24826747981](https://github.com/suprsend/cli/actions/runs/24826747981)) failed at the npm publish step with a 404:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
...
npm error 404 Not Found - PUT https://registry.npmjs.org/@suprsend%2fcli-darwin-x64
```

Root cause: Node 20 ships with npm 10.x, which signs the provenance attestation but doesn't perform the OIDC *token exchange* that trusted publishing needs. It falls back to the `setup-node` placeholder `_authToken` (`XXXXX-XXXXX-XXXXX-XXXXX`), which the registry rejects.

Trusted publisher config on the packages was correct — only the publisher-side npm CLI was the problem.

## Fix

Follow [npm's trusted-publishing docs](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers) exactly: bump to `actions/setup-node@v6` + `node-version: '24'`. The npm that ships with Node 24 performs the OIDC token exchange automatically.

```diff
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
```

No other changes needed. `id-token: write` is already granted on the job (it's been there for AWS/cosign).

## Test plan

- [ ] After merge, cut a release tag and verify all 7 npm packages publish with provenance at the tag version.