### PR TITLE
genskills: narrow cli skill trigger to running commands only

### DIFF
--- a/internal/commands/skills.go
+++ b/internal/commands/skills.go
@@ -32,7 +32,7 @@ var genSkillsCmd = &cobra.Command{
 		// Generate skills
 		doc.GenSkillsDir(rootCmd, dir, doc.SkillsConfig{
 			Name:        "suprsend-cli",
-			Description: "SuprSend CLI is a command-line interface tool for managing your SuprSend account and resources. It provides a convenient way to interact with the SuprSend API, allowing you to perform various operations such as managing workspaces, workflows, templates, categories, events, schemas, and translations. Use when pushing, pulling, or committing SuprSend resources from local files, generating type definitions from JSON schemas, syncing between workspaces, or running CLI commands like `suprsend template pull`, `suprsend workflow push`, or `suprsend schema commit`.",
+			Description: "SuprSend CLI tool for managing SuprSend account and resources from the command line — workspaces, workflows, templates, categories, events, schemas, and translations. Use ONLY when the user wants the agent to RUN a `suprsend ...` command (e.g. \"push my template\", \"pull all workflows\", \"sync staging to prod\", \"generate Python types\") or asks about a specific CLI command's flags/behavior (\"what does `suprsend template commit --dry-run` do?\"). Do NOT load for documentation, lookup, or conceptual SuprSend questions (\"how does batching work\", \"what is a variant\", \"explain delivery nodes\") — load `suprsend-docs-support` for those. Do NOT load when the user is authoring workflow or template JSON without invoking the CLI — load `suprsend-workflow-schema` or `suprsend-template-schema` for those.",
 			Metadata: map[string]string{
 				"author":   "suprsend",
 				"category": "cli",

--- a/skills/suprsend-cli/SKILL.md
+++ b/skills/suprsend-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suprsend-cli
-description: "SuprSend CLI is a command-line interface tool for managing your SuprSend account and resources. It provides a convenient way to interact with the SuprSend API, allowing you to perform various operations such as managing workspaces, workflows, templates, categories, events, schemas, and translations. Use when pushing, pulling, or committing SuprSend resources from local files, generating type definitions from JSON schemas, syncing between workspaces, or running CLI commands like `suprsend template pull`, `suprsend workflow push`, or `suprsend schema commit`."
+description: "SuprSend CLI tool for managing SuprSend account and resources from the command line — workspaces, workflows, templates, categories, events, schemas, and translations. Use ONLY when the user wants the agent to RUN a `suprsend ...` command (e.g. \"push my template\", \"pull all workflows\", \"sync staging to prod\", \"generate Python types\") or asks about a specific CLI command's flags/behavior (\"what does `suprsend template commit --dry-run` do?\"). Do NOT load for documentation, lookup, or conceptual SuprSend questions (\"how does batching work\", \"what is a variant\", \"explain delivery nodes\") — load `suprsend-docs-support` for those. Do NOT load when the user is authoring workflow or template JSON without invoking the CLI — load `suprsend-workflow-schema` or `suprsend-template-schema` for those."
 metadata:
   author: suprsend
   category: cli


### PR DESCRIPTION
## Why

Observed routing failure: the prompt **"fetch batching documentation from suprsend"** was loading `suprsend-cli` even though the user wanted docs. The cli skill's description led with *"Use when pushing, pulling, or committing SuprSend resources from local files, generating type definitions from JSON schemas, syncing between workspaces, or running CLI commands…"* — the verb cluster *push / pull / commit* semantically anchored to "fetch," so cli beat `suprsend-docs-support` (the right skill).

This PR rewrites the Description to bind ONLY when the agent is about to *run* a `suprsend …` command, with explicit disclaimers that route lookups and authoring elsewhere.

## New Description

```
SuprSend CLI tool for managing SuprSend account and resources from the
command line — workspaces, workflows, templates, categories, events,
schemas, and translations. Use ONLY when the user wants the agent to
RUN a `suprsend ...` command (e.g. "push my template", "pull all
workflows", "sync staging to prod", "generate Python types") or asks
about a specific CLI command's flags/behavior ("what does `suprsend
template commit --dry-run` do?"). Do NOT load for documentation,
lookup, or conceptual SuprSend questions ("how does batching work",
"what is a variant", "explain delivery nodes") — load
`suprsend-docs-support` for those. Do NOT load when the user is
authoring workflow or template JSON without invoking the CLI — load
`suprsend-workflow-schema` or `suprsend-template-schema` for those.
```

Total length: under the 1024-char `description` cap.

## Matching changes

The corresponding rewrites to the three skills in [`suprsend/skills`](https://github.com/suprsend/skills) land in [#10](https://github.com/suprsend/skills/pull/10) there. Once both merge, the four-skill routing model is consistent:

| Skill | Triggers ONLY for |
|---|---|
| `suprsend-cli` | Running a `suprsend …` command |
| `suprsend-workflow-schema` | Authoring/editing workflow JSON |
| `suprsend-template-schema` | Authoring/editing template variant JSON |
| `suprsend-docs-support` | Default for everything else (fetch / read / explain / look up) |

## Files changed

- `internal/commands/skills.go` — `Description` rewrite
- `skills/suprsend-cli/SKILL.md` — regenerated via `go run ./cmd/suprsend/main.go genskills skills/`

Per-command Tips and `Metadata` from [#66](https://github.com/suprsend/cli/pull/66) are untouched.

## Test plan

- [x] `go build ./...` passes
- [x] Regenerated SKILL.md description is valid YAML, under the 1024-char cap
- [ ] After merge, the test prompts in the linked skills PR route to the expected skill (manual spot-check)